### PR TITLE
Issue 9

### DIFF
--- a/otc/node_embedding.h
+++ b/otc/node_embedding.h
@@ -156,10 +156,10 @@ class NodeEmbedding {
                             const std::map<const T *, NodeEmbedding<T, U> > & sn2ne) const;
     void resolveGivenUncontestedMonophyly(T & scaffoldNode,
                                           SupertreeContextWithSplits & sc);
-    void exportSubproblemAndFakeResolution(T & scaffoldNode,
-                                           const std::string & exportDir,
-                                           std::ostream * exportStream, // nonnull to override exportdir
-                                           SupertreeContextWithSplits & sc);
+    void exportSubproblemAndResolve(T & scaffoldNode,
+                                    const std::string & exportDir,
+                                    std::ostream * exportStream, // nonnull to override exportdir
+                                    SupertreeContextWithSplits & sc);
     void collapseGroup(T & scaffoldNode, SupertreeContext<T, U> & sc);
     void pruneCollapsedNode(T & scaffoldNode, SupertreeContextWithSplits & sc);
     void constructPhyloGraphAndCollapseIfNecessary(T & scaffoldNode, SupertreeContextWithSplits  & sc);

--- a/otc/node_embedding.h
+++ b/otc/node_embedding.h
@@ -73,6 +73,17 @@ class NodeEmbedding {
         }
         return t;
     }
+    std::set<U *> getPhyloNodes(std::size_t treeIndex) const {
+        auto neIt = nodeEmbeddings.find(treeIndex);
+        std::set<U *> r;
+        if (neIt == nodeEmbeddings.end()) {
+            return r;
+        }
+        for (const auto & np : neIt->second) {
+            r.insert(np->phyloNode);
+        }
+        return r;
+    }
     std::size_t getNumLoopTrees() const {
         std::set<std::size_t> keys;
         for (auto i : loopEmbeddings) {
@@ -182,6 +193,10 @@ class NodeEmbedding {
                         long ottId,
                         std::map<const T *, NodeEmbedding<T, U> > & n2ne);
     void mergeExitEmbeddingsIfMultiple();
+    void resolveParentInFavorOfThisNode(
+                        T & scaffoldNode,
+                        std::size_t treeIndex,
+                        SupertreeContextWithSplits & sc);
     const TreeToPathPairs & getExitEmbeddings() const {
         return edgeBelowEmbeddings;
     }
@@ -272,7 +287,7 @@ inline std::map<U *, U*> NodeEmbedding<T, U>::getLoopedPhyloNd2Par(std::size_t t
 }
 
 template<typename T, typename U>
-inline std::map<U *, U*> NodeEmbedding<T, U>::getExitPhyloNd2Par(std::size_t treeInd) const {
+inline std::map<U *, U *> NodeEmbedding<T, U>::getExitPhyloNd2Par(std::size_t treeInd) const {
     return getNd2ParForKey(treeInd, edgeBelowEmbeddings);
 }
 

--- a/otc/pairings.h
+++ b/otc/pairings.h
@@ -91,6 +91,17 @@ class PathPairing {
         assert(phyloChild->getParent() == phyloParent);
         assert(scaffoldAnc == scaffoldDes || isAncestorDesNoIter(scaffoldAnc, scaffoldDes));
     }
+    PathPairing(T * scafPar,
+                U * phyPar,
+                const NodePairing<T, U> & child)
+        :scaffoldDes(child.scaffoldNode),
+        scaffoldAnc(scafPar),
+        phyloChild(child.phyloNode),
+        phyloParent(phyPar),
+        currChildOttIdSet(child.phyloNode->getData().desIds) {
+        assert(phyloChild->getParent() == phyloParent);
+        assert(scaffoldAnc == scaffoldDes || isAncestorDesNoIter(scaffoldAnc, scaffoldDes));
+    }
     // as Paths get paired back deeper in the tree, the ID may be mapped to a higher
     // taxon. The currChildOttIdSet starts out identical to the phylogenetic node's 
     // descendant Ott Id set. But may change to reflect this remapping to the effective

--- a/otc/supertree_context.h
+++ b/otc/supertree_context.h
@@ -32,7 +32,8 @@ class SupertreeContext {
         std::map<long, typename U::node_type *> & scaffoldOttId2Node;
         RootedTree<RTSplits, RTreeOttIDMapping<RTSplits> > & scaffoldTree; // should adjust the templating to make more generic
         std::map<std::size_t, std::set<NodeWithSplits *> > prunedSubtrees; // when a tip is mapped to a non-monophyletc terminal it is pruned
-
+        std::list<NodePairingWithSplits> nodePairingsFromResolve;
+        std::list<PathPairingWithSplits> pathPairingsFromResolve;
         void log(SupertreeCtorEvent e, const U & node) {
             if (e == COLLAPSE_TAXON) {
                 events.emplace_back(LogEvent{e, std::string("ott") + std::to_string(node.getOttId())});

--- a/tools/uncontesteddecompose.cpp
+++ b/tools/uncontesteddecompose.cpp
@@ -29,7 +29,7 @@ class UncontestedTaxonDecompose : public EmbeddingCLI {
             //    _getEmbeddingForNode(scaffoldNd->getParent()).debugNodeEmbedding(" parent before export", true, scaffoldNdToNodeEmbedding);
             //}
             LOG(INFO) << "    Uncontested";
-            thr.exportSubproblemAndFakeResolution(*scaffoldNd, exportDir, exportStream, sc);
+            thr.exportSubproblemAndResolve(*scaffoldNd, exportDir, exportStream, sc);
             //if (scaffoldNd->getParent()) {
             //    _getEmbeddingForNode(scaffoldNd->getParent()).debugNodeEmbedding("after export", true, scaffoldNdToNodeEmbedding);
             //}


### PR DESCRIPTION
resolving polytomy in support of an uncontested node rather than trying to emulate the tree without restructuring.  This addresses the small test that was inspired by the Chlorella case - but the full decomposition has not been rerun. This should fix that issue, but that has not been verified...