### PR TITLE
Delete subproblems on make clean

### DIFF
--- a/supertree/Makefile.synth-v3
+++ b/supertree/Makefile.synth-v3
@@ -33,15 +33,19 @@ ARTIFACTS=$(STEP_5_DIR)/step-5-phylo-args.txt \
 	$(STEP_5_PHYLO_OUTPUT_PATHS) \
 	$(STEP_7_PHYLO_OUTPUT_TREE_PATHS) \
 	$(STEP_7_PHYLO_OUTPUT_TREE_NAME_PATHS) \
-	$(STEP_7_PHYLO_OUTPUT_MD5_PATHS)
+	$(STEP_7_PHYLO_OUTPUT_MD5_PATHS) \
+	$(SUBPROB_RAW_EXPORT_DIR)/*
 
 
 # default is "all"
 all: $(ARTIFACTS)
 
-
 clean:
-	rm -f $(ARTIFACTS) $(SUBPROB_RAW_EXPORT_DIR)/* && rmdir $(SUBPROB_RAW_EXPORT_DIR)
+	rm -f $(ARTIFACTS) && rmdir $(SUBPROB_RAW_EXPORT_DIR)
+
+cleanall:
+	rm -f $(ARTIFACTS) $(STEP_4_PHYLO_OUTPUT_PATHS) $(STEP_1_DIR)/taxonomy.tre
+	rmdir $(SUBPROB_RAW_EXPORT_DIR)
 
 # step-5-phylo-args is a list of the relative filepaths to the phylo inputs for step 5 (higher level tip expansion)
 #	relative to the supertree dir.  

--- a/supertree/Makefile.synth-v3
+++ b/supertree/Makefile.synth-v3
@@ -33,8 +33,7 @@ ARTIFACTS=$(STEP_5_DIR)/step-5-phylo-args.txt \
 	$(STEP_5_PHYLO_OUTPUT_PATHS) \
 	$(STEP_7_PHYLO_OUTPUT_TREE_PATHS) \
 	$(STEP_7_PHYLO_OUTPUT_TREE_NAME_PATHS) \
-	$(STEP_7_PHYLO_OUTPUT_MD5_PATHS) \
-	$(SUBPROB_RAW_EXPORT_DIR)
+	$(STEP_7_PHYLO_OUTPUT_MD5_PATHS)
 
 
 # default is "all"
@@ -42,7 +41,7 @@ all: $(ARTIFACTS)
 
 
 clean:
-	rm -rf $(ARTIFACTS)
+	rm -f $(ARTIFACTS) $(SUBPROB_RAW_EXPORT_DIR)/* && rmdir $(SUBPROB_RAW_EXPORT_DIR)
 
 # step-5-phylo-args is a list of the relative filepaths to the phylo inputs for step 5 (higher level tip expansion)
 #	relative to the supertree dir.  

--- a/supertree/Makefile.synth-v3
+++ b/supertree/Makefile.synth-v3
@@ -33,15 +33,16 @@ ARTIFACTS=$(STEP_5_DIR)/step-5-phylo-args.txt \
 	$(STEP_5_PHYLO_OUTPUT_PATHS) \
 	$(STEP_7_PHYLO_OUTPUT_TREE_PATHS) \
 	$(STEP_7_PHYLO_OUTPUT_TREE_NAME_PATHS) \
-	$(STEP_7_PHYLO_OUTPUT_MD5_PATHS)
+	$(STEP_7_PHYLO_OUTPUT_MD5_PATHS) \
+	$(SUBPROB_RAW_EXPORT_DIR)
 
 
 # default is "all"
 all: $(ARTIFACTS)
-	
+
 
 clean:
-	rm -f $(ARTIFACTS)
+	rm -rf $(ARTIFACTS)
 
 # step-5-phylo-args is a list of the relative filepaths to the phylo inputs for step 5 (higher level tip expansion)
 #	relative to the supertree dir.  

--- a/supertree/Makefile.synth-v3
+++ b/supertree/Makefile.synth-v3
@@ -44,8 +44,8 @@ clean:
 	rm -f $(ARTIFACTS) && rmdir $(SUBPROB_RAW_EXPORT_DIR)
 
 cleanall:
-	rm -f $(ARTIFACTS) $(STEP_4_PHYLO_OUTPUT_PATHS) $(STEP_1_DIR)/taxonomy.tre
-	rmdir $(SUBPROB_RAW_EXPORT_DIR)
+	rm -f $(ARTIFACTS) $(STEP_4_PHYLO_OUTPUT_PATHS) $(STEP_1_DIR)/taxonomy.tre logs/*
+	rmdir $(SUBPROB_RAW_EXPORT_DIR) logs
 
 # step-5-phylo-args is a list of the relative filepaths to the phylo inputs for step 5 (higher level tip expansion)
 #	relative to the supertree dir.  


### PR DESCRIPTION
Minor edit to `Makefile.synth-v3` to delete subproblems when doing `Make -f Makefile.synth-v3 clean`.