### PR TITLE
Fix the ability to build without webservices.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,18 +28,22 @@ boost = dependency('boost', modules : ['program_options','system','filesystem'],
 
 json = declare_dependency(include_directories: include_directories('otc'))
 
-# We don't need ssl and curl unless librested itself was compiled with them.
-#ssl  = dependency('openssl')
-#curl = dependency('libcurl')
-# Can we test if we need them to link with restbed?
-threads = dependency('threads')
-restbed_lib = cpp.find_library('restbed')
-restbed_deps = [restbed_lib, threads] # ssl, curl?
-restbed = declare_dependency(dependencies: restbed_deps)
-# FIXME: we could put this back if we made enabling webservices a build-if-you-can tri-state option.
-# if not restbed.found() or not ssl.found() or not curl.found()
-#  restbed = disabler()
-# endif
+if get_option('webservices')
+  # We don't need ssl and curl unless librested itself was compiled with them.
+  #ssl  = dependency('openssl')
+  #curl = dependency('libcurl')
+  # Can we test if we need them to link with restbed?
+  threads = dependency('threads')
+  restbed_lib = cpp.find_library('restbed')
+  restbed_deps = [restbed_lib, threads] # ssl, curl?
+  restbed = declare_dependency(dependencies: restbed_deps)
+  # FIXME: we could put this back if we made enabling webservices a build-if-you-can tri-state option.
+  # if not restbed.found() or not ssl.found() or not curl.found()
+  #  restbed = disabler()
+  # endif
+else
+  restbed = dependency('', required: false)
+endif
 
 rpath = '$ORIGIN/../'+get_option('libdir')
 
@@ -48,7 +52,9 @@ subdir('otc')
 # build tools
 subdir('tools')
 # build web services
-subdir('ws')
+if get_option('webservices')
+  subdir('ws')
+endif
 
 # check if python subprocess module is installed
 if true

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('webservices', type : 'boolean', value : true,
+       description : 'enables compilation of the ws subdirectory (requires restbed be installed)')

--- a/otc/meson.build
+++ b/otc/meson.build
@@ -19,6 +19,9 @@ libotcetera_sources = [
   'tree.cpp',
   'util.cpp',
   'write_dot.cpp',
+  ]
+
+libotcetera_ws_sources = [
   'ws/conflictws.cpp',
   'ws/taxonomyws.cpp',
   'ws/tnrsws.cpp',
@@ -26,7 +29,11 @@ libotcetera_sources = [
   'ws/tolwsadaptors.cpp',
   'ws/trees_to_serve.cpp', 
   'ws/nexson/nexson.cpp',
-  ]
+]
+
+if get_option('webservices')
+  libotcetera_sources += libotcetera_ws_sources
+endif
 
 otc_inc = include_directories('..')
 otc_lib = shared_library('otcetera',

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -51,8 +51,12 @@ programs = [
   ['tree-tool',  'tree-tool'],
   ['broken-taxa',  'broken-taxa'],
   ['unprune-solution-and-name-unnamed-nodes', 'unprune-solution-and-name-unnamed-nodes'],
-  ['tnrs-cli', 'tnrs-cli']
   ]
+
+# we need restbed for this, indirectly.
+if get_option('webservices')
+  programs += [['tnrs-cli', 'tnrs-cli']]
+endif
 
 foreach program : programs
   executable('otc-'+program[1],


### PR DESCRIPTION
This allows disabling webservices again.

I was able to successfully build otcetera in 3 different ways with this branch.
- the synth version (webservices disabled)
- the ws version (webservices enabled)
- the cli version (webservices enabled?)

Maybe the last two are the same now.