### PR TITLE
Extinct flag arguson

### DIFF
--- a/otc/taxonomy/flags.cpp
+++ b/otc/taxonomy/flags.cpp
@@ -178,4 +178,11 @@ std::vector<std::string> flags_to_string_vec(const std::bitset<32> flags)
     return f;
 }
 
+bool is_extinct(tax_flags flags)
+{
+    static int extinct_bit = flag_from_string("extinct");
+    static int extinct_inherited_bit = flag_from_string("extinct_inherited");
+    return flags.test(extinct_bit) or flags.test(extinct_inherited_bit);
+}
+
 } // namespace otc

--- a/otc/taxonomy/flags.h
+++ b/otc/taxonomy/flags.h
@@ -20,6 +20,8 @@ std::vector<std::string> flags_to_string_vec(const tax_flags flags);
 std::bitset<32> cleaning_flags_from_config_file(const std::string& filename);
 std::bitset<32> regrafting_flags_from_config_file(const std::string& filename);
 
+bool is_extinct(tax_flags);
+
 } //namespace otc
 
 #endif

--- a/otc/taxonomy/taxonomy.cpp
+++ b/otc/taxonomy/taxonomy.cpp
@@ -160,6 +160,10 @@ const std::string empty_string;
 const set<string> indexed_source_prefixes = {"ncbi", "gbif", "worms", "if", "irmng"};
 std::set<std::string> rank_strings;
 
+bool TaxonomyRecord::is_extinct() const
+{
+    return ::is_extinct(flags);
+}
 
 TaxonomyRecord::TaxonomyRecord(const string& line_)
     :line(line_) {
@@ -577,6 +581,11 @@ RichTaxonomy load_rich_taxonomy(const variables_map& args) {
         cleaning_flags = flags_from_string(args["clean"].as<string>());
     }
     return {taxonomy_dir, cleaning_flags, keep_root};
+}
+
+bool RTRichTaxNodeData::is_extinct() const
+{
+    return ::is_extinct(flags);
 }
 
 

--- a/otc/taxonomy/taxonomy.h
+++ b/otc/taxonomy/taxonomy.h
@@ -145,6 +145,7 @@ struct TaxonomyRecord {
     TaxonomyRecord& operator=(const TaxonomyRecord& tr) = delete;
     TaxonomyRecord(TaxonomyRecord&& tr) = default;
     TaxonomyRecord(TaxonomyRecord& tr) = delete;
+    bool is_extinct() const;
     explicit TaxonomyRecord(const std::string& line);
     std::vector<std::string> sourceinfoAsVec() const {
         std::string si = std::string(sourceinfo);
@@ -256,6 +257,7 @@ class RTRichTaxNodeData {
         auto vs = this->sourceinfoAsVec();
         return sources_vec_as_json(vs);
     }
+    bool is_extinct() const;
 };
 
 typedef RootedTreeNode<RTRichTaxNodeData> RTRichTaxNode;

--- a/otc/ws/tolws.cpp
+++ b/otc/ws/tolws.cpp
@@ -97,6 +97,9 @@ void add_basic_node_info(const RichTaxonomy & taxonomy, const SumTreeNode_t & nd
     else
         noderepr["num_tips"] = nd.get_data().num_tips;
 
+    if (is_arguson)
+        noderepr["extinct"] = nd.get_data().is_extinct();
+
     if (nd.has_ott_id()) {
         auto nd_id = nd.get_ott_id();
         const auto * nd_taxon = taxonomy.included_taxon_from_id(nd_id);

--- a/otc/ws/tolws.h
+++ b/otc/ws/tolws.h
@@ -63,6 +63,8 @@ class SumTreeNodeData {
         vec_src_node_ids terminal;
 #   endif
     bool was_uncontested = false;
+    bool extinct_mark = false;  // extinctness means that the node has >= 1 descendant (including itself), and all descendants are extinct.
+    bool is_extinct() const {return extinct_mark;}
     uint32_t num_tips = 0;
 };
 

--- a/ws/tolwsbooting.cpp
+++ b/ws/tolwsbooting.cpp
@@ -1153,7 +1153,44 @@ inline std::size_t calc_memory_used(const RichTaxonomy &rt, MemoryBookkeeper &mb
 
 #endif
 
+void mark_summary_tree_nodes_extinct(SummaryTree_t& tree, const RichTaxonomy& taxonomy)
+{
+    // compute extinctness for each node.  Post means that a node is only visited after all its children.
+    for (auto node: iter_post(tree))
+    {
+        auto& node_data = node->get_data();
+        if (node->is_tip())
+        {
+            auto id = node->get_ott_id();
+            auto& taxon = taxonomy.included_taxon_from_id(id)->get_data();
+            node_data.extinct_mark = taxon.is_extinct();
+        }
+        else
+        {
+            // If any child is not extinct, then this node is not extinct either.
+            node_data.extinct_mark = true;
+            for (auto c : iter_child_const(*node))
+                if (not c->get_data().is_extinct())
+                    node_data.extinct_mark = false;
 
+            // Complain about higher taxa with extinctness that doesn't match the computed extinctness.
+            if (node->has_ott_id())
+            {
+                auto id = node->get_ott_id();
+                auto& taxon = taxonomy.included_taxon_from_id(id)->get_data();
+                if (node_data.is_extinct() != taxon.is_extinct())
+                {
+                    LOG(WARNING)<<"Higher taxon "<<taxon.possibly_nonunique_name<<" is extinct="<<taxon.is_extinct()<<"  but the computed extinctness is extinct="<<node_data.is_extinct();
+                    for (auto c : iter_child_const(*node))
+                        if (not c->get_data().is_extinct())
+                            LOG(WARNING)<<"    Child "<<c->get_name()<<" is NOT extinct!";
+                        else
+                            LOG(WARNING)<<"    Child "<<c->get_name()<<" is EXTINCT!";
+                }
+            }
+        }
+    }
+}
 
 bool read_tree_and_annotations(const fs::path & config_path,
                                const fs::path & tree_path,
@@ -1199,6 +1236,9 @@ bool read_tree_and_annotations(const fs::path & config_path,
 #   endif
     auto [tree,sta] = tts.get_new_tree_and_annotations(config_path.native(), tree_path.native());
     try {
+
+        mark_summary_tree_nodes_extinct(tree, taxonomy);
+
         sta = annotations_obj;
         json tref;
         tref["taxonomy"] = taxonomy.get_version();

--- a/ws/tolwsbooting.cpp
+++ b/ws/tolwsbooting.cpp
@@ -1197,10 +1197,8 @@ bool read_tree_and_annotations(const fs::path & config_path,
         auto tax_mem = calc_memory_used(taxonomy, tax_mem_b);
         write_memory_bookkeeping(LOG(INFO), tax_mem_b, "taxonomy", tax_mem);
 #   endif
-    auto tree_and_ann = tts.get_new_tree_and_annotations(config_path.native(), tree_path.native());
+    auto [tree,sta] = tts.get_new_tree_and_annotations(config_path.native(), tree_path.native());
     try {
-        SummaryTree_t & tree = tree_and_ann.first;
-        SummaryTreeAnnotation & sta = tree_and_ann.second;
         sta = annotations_obj;
         json tref;
         tref["taxonomy"] = taxonomy.get_version();


### PR DESCRIPTION
This branch sets "extinct": true for extinct taxa, and "extinct": false for extant taxa:
```
{ 
    "extinct": false,
    "node_id": "ott413056",
    "num_tips": 26,
    "supported_by": {
     "ott3.0draft6": "ott413056"
    },
   "taxon": {
     "name": "Amigdoscalpellum",
     "ott_id": 413056,
     "rank": "genus",
```
I deployed this branch on devtapi, but devapi is serving 10.4 instead of 12.3, which means that a lot of the extinct taxa in 12.3 are pruned.