### PR TITLE
Make the otcetera web services forward OTT ids in names like `ott12345`

### DIFF
--- a/otc/ws/tolws.cpp
+++ b/otc/ws/tolws.cpp
@@ -313,7 +313,7 @@ bool is_ancestor_of(N* f, N* s)
     return (sec_ind >= fdata->trav_enter and sec_ind <= fdata->trav_exit);
 }
 
-node_lookup_t find_node_by_id_str(const SummaryTree_t & tree, const string & node_id)
+node_lookup_t find_node_by_id_str(const SummaryTree_t & tree, const RichTaxonomy& taxonomy, const string & node_id)
 {
     const auto & tree_data = tree.get_data();
 
@@ -355,11 +355,11 @@ node_lookup_t find_node_by_id_str(const SummaryTree_t & tree, const string & nod
         assert(matches.size() >= 2);
         std::string first_id = matches[1];
         std::string second_id = matches[2];
-        auto result1 = find_node_by_id_str(tree, first_id);
+        auto result1 = find_node_by_id_str(tree, taxonomy, first_id);
         if (result1.node == nullptr) {
             return result1;
         }
-        auto result2 = find_node_by_id_str(tree, second_id);
+        auto result2 = find_node_by_id_str(tree, taxonomy, second_id);
         if (result2.node == nullptr) {
             return result2;
         }
@@ -368,9 +368,9 @@ node_lookup_t find_node_by_id_str(const SummaryTree_t & tree, const string & nod
     return {};
 }
 
-node_lookup_t find_required_node_by_id_str(const SummaryTree_t & tree, const string & node_id)
+node_lookup_t find_required_node_by_id_str(const SummaryTree_t & tree, const RichTaxonomy& taxonomy, const string & node_id)
 {
-    auto result = find_node_by_id_str(tree, node_id);
+    auto result = find_node_by_id_str(tree, taxonomy, node_id);
     if (not result.node) {
         throw OTCBadRequest() << "node_id '" << node_id << "' was not found!";
     }
@@ -512,7 +512,9 @@ string node_info_ws_method(const TreesToServe & tts,
                            bool include_lineage) {
     LOG(DEBUG)<<"Got to node_info_ws_method( )";
 
-    auto result = find_required_node_by_id_str(*tree_ptr, node_id);
+    auto locked_taxonomy = tts.get_readable_taxonomy();
+    const auto & taxonomy = locked_taxonomy.first;
+    auto result = find_required_node_by_id_str(*tree_ptr, taxonomy, node_id);
 
     auto response = node_info_json(tts, sta, result.node, include_lineage);
     response["query"] = node_id;
@@ -528,7 +530,7 @@ pair<vector<const SumTreeNode_t*>,json> find_nodes_for_id_strings(const RichTaxo
     json broken = json::object();
     optional<string> bad_node_id;
     for (auto node_id : node_ids) {
-        auto result = find_node_by_id_str(*tree_ptr, node_id);
+        auto result = find_node_by_id_str(*tree_ptr, taxonomy, node_id);
         if (not result.node or (result.was_broken and fail_broken)) {
             // Possible statuses:
             //  - invalid    (never minted id)
@@ -718,12 +720,13 @@ auto lookup(const Map& m, const Key& k)
 
 
 const SumTreeNode_t * get_node_for_subtree(const SummaryTree_t * tree_ptr,
-                                           const string & node_id, 
+                                           const string & node_id,
+                                           const RichTaxonomy& taxonomy,
                                            int height_limit,
                                            uint32_t tip_limit)
 {
     assert(tree_ptr != nullptr);
-    auto result = find_required_node_by_id_str(*tree_ptr, node_id);
+    auto result = find_required_node_by_id_str(*tree_ptr, taxonomy, node_id);
     if (result.was_broken) {
         json broken;
         broken["mrca"] = get_synth_node_label(result.node);
@@ -849,9 +852,9 @@ string newick_subtree_ws_method(const TreesToServe & tts,
                                 int height_limit)
 {
     const uint32_t NEWICK_TIP_LIMIT = 100000;
-    auto focal = get_node_for_subtree(tree_ptr, node_id, height_limit, NEWICK_TIP_LIMIT);
     auto locked_taxonomy = tts.get_readable_taxonomy();
     const auto & taxonomy = locked_taxonomy.first;
+    auto focal = get_node_for_subtree(tree_ptr, node_id, taxonomy, height_limit, NEWICK_TIP_LIMIT);
     NodeNamerSupportedByStasher nnsbs(label_format, taxonomy, tts);
     ostringstream out;
     write_newick_generic<const SumTreeNode_t *, NodeNamerSupportedByStasher>(out, focal, nnsbs, include_all_node_labels, height_limit);
@@ -891,7 +894,9 @@ string arguson_subtree_ws_method(const TreesToServe & tts,
                                  const string & node_id,
                                  int height_limit) {
     const uint32_t NEWICK_TIP_LIMIT = 25000;
-    auto focal = get_node_for_subtree(tree_ptr, node_id, height_limit, NEWICK_TIP_LIMIT);
+    auto locked_taxonomy = tts.get_readable_taxonomy();
+    const auto & taxonomy = locked_taxonomy.first;
+    auto focal = get_node_for_subtree(tree_ptr, node_id, taxonomy, height_limit, NEWICK_TIP_LIMIT);
     json response;
     response["synth_id"] = sta->synth_id;
     set<string> usedSrcIds;

--- a/otc/ws/tolws.h
+++ b/otc/ws/tolws.h
@@ -257,7 +257,7 @@ struct node_lookup_t
     node_lookup_t(const SumTreeNode_t* n):node(n) {}
 };
 
-node_lookup_t find_node_by_id_str(const SummaryTree_t & tree, const std::string & node_id);
+node_lookup_t find_node_by_id_str(const SummaryTree_t & tree, const RichTaxonomy&, const std::string & node_id);
 
 class TreesToServe;
 

--- a/ws/tolwsbooting.cpp
+++ b/ws/tolwsbooting.cpp
@@ -1208,7 +1208,7 @@ bool read_tree_and_annotations(const fs::path & config_path,
         //const auto & n2n = sum_tree_data.name_to_node;
         for (json::const_iterator nit = node_obj.begin(); nit != node_obj.end(); ++nit) {
             string k = nit.key();
-            auto result = find_node_by_id_str(tree, k);
+            auto result = find_node_by_id_str(tree, taxonomy, k);
             //auto stnit = n2n.find(k);
             if (result.node == nullptr) {
                 throw OTCError() << "Node " << k << " from annotations not found in tree.";
@@ -1327,11 +1327,11 @@ bool read_tree_and_annotations(const fs::path & config_path,
                 for (json::const_iterator ai_it = attach_obj.begin(); ai_it != attach_obj.end(); ++ai_it) {
                     attach_id_list.push_back(ai_it.key());
                 }
-                auto mrca_result = find_node_by_id_str(tree, mrca_id);
+                auto mrca_result = find_node_by_id_str(tree, taxonomy, mrca_id);
                 vector<const SumTreeNode_t *> avec;
                 avec.reserve(attach_id_list.size());
                 for (auto attach_id : attach_id_list) {
-                    auto [anptr, _] = find_node_by_id_str(tree, attach_id);
+                    auto [anptr, _] = find_node_by_id_str(tree, taxonomy, attach_id);
                     assert(anptr != nullptr);
                     avec.push_back(anptr);
                 }


### PR DESCRIPTION
Our major helper routine `find_node_by_id_str( )` didn't have access to the taxonomy, so it couldn't forward.

Solved by passing the taxonomy into that routine, and then using it to forward OTT ids before trying to find those ids in the synth tree.